### PR TITLE
Introduce Cache API for faster loco caching.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -188,15 +188,6 @@ function isReverseProxy(config) {
   return !config.domain
 }
 
-/**
- * @param {string} str
- * @return {maxAge: number | undefined}
- */
-function parseCacheControl(str) {
-  const maxAge = str.match(/max-age=(\d+)/)[1]
-  return { maxAge }
-}
-
 /** @param {!ConfigDef} config */
 function validateConfiguration(config) {
   const allowed = new Set([

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -40,6 +40,7 @@ beforeEach(() => {
 
   global.Response = Response
   global.HTMLRewriter = HTMLRewriter
+  global.caches = { default: { match: () => null } }
 })
 
 describe('handleRequest', () => {


### PR DESCRIPTION
**summary**
Introduces usage of the [Cache API](https://developers.cloudflare.com/workers/runtime-apis/cache). I'm not 100% confident about the utility of this change. I'm seeing the TTFB be slightly faster on average (i.e. sometimes breaking 30ms).


Bonus change: respect cache-control header, and use a 15m default TTL.