### PR TITLE
prod command needs --env flag too.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,11 +6,11 @@
   "scripts": {
     "start": "wrangler dev --env=dev",
     "beta": "wrangler publish --env=beta",
-    "prod": "wrangler publish"
+    "prod": "wrangler publish --env=prod"
   },
   "author": "AMPHTML Team",
   "license": "Apache-2.0",
   "dependencies": {
-    "@ampproject/cloudflare-optimizer-scripts": "0.0.6"
+    "@ampproject/cloudflare-optimizer-scripts": "2.8.1"
   }
 }


### PR DESCRIPTION
Fixes `npm run prod` as discovered by @TugT4G in https://github.com/ampproject/cloudflare-amp-optimizer/issues/28